### PR TITLE
Remove use of service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*~
+letsencrypt-zimbra.cfg

--- a/letsencrypt-zimbra.cfg.example
+++ b/letsencrypt-zimbra.cfg.example
@@ -1,0 +1,43 @@
+### mail variables ###
+email="" # e.g. admin@zimbra.example.com
+sendmail="/opt/zimbra/postfix/sbin/sendmail" # 8.7 and later: /opt/zimbra/common/sbin/sendmail
+
+### reminder mail ###
+subject="Certificate renewal in $1 day(s)"
+message="Hello,
+this is just a kindly reminder that a letsencrypt-zimbra tool
+will try to obtain and install new zimbra certificate in $1 day(s).
+
+Sincerelly yours,
+letsencrypt-zimbra"
+
+### success mail ###
+subject="Certificate has been renewed"
+message="Hello,
+this is just a kindly reminder that your letsencrypt-zimbra tool
+renewed successfully your Zimbra certificate!
+
+Sincerelly yours,
+letsencrypt-zimbra"
+
+
+### letsencrypt tool ###
+# common name in the certificate
+CN="mail.theajty.com"
+letsencrypt="/root/letsencrypt/letsencrypt-auto"
+
+zimbra_service="zimbra"
+zimbra_user="zimbra"
+zimbra_dir="/opt/zimbra"
+
+zimbra_bin_dir="${zimbra_dir}/bin"
+zmcertmgr="${zimbra_bin_dir}/zmcertmgr"
+
+zimbra_ssl_dir="${zimbra_dir}/ssl/zimbra/commercial"
+zimbra_key="${zimbra_ssl_dir}/commercial.key"
+
+
+# the name of file which letsencrypt will generate
+letsencrypt_issued_cert_file="0000_cert.pem"
+# intermediate CA
+letsencrypt_issued_intermediate_CA_file="0000_chain.pem"

--- a/letsencrypt-zimbra.cfg.example
+++ b/letsencrypt-zimbra.cfg.example
@@ -26,7 +26,6 @@ letsencrypt-zimbra"
 CN="mail.theajty.com"
 letsencrypt="/root/letsencrypt/letsencrypt-auto"
 
-zimbra_service="zimbra"
 zimbra_user="zimbra"
 zimbra_dir="/opt/zimbra"
 

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -29,29 +29,10 @@ USAGE="USAGE
 # --------------------------------------------------------------------
 # -- Variables -------------------------------------------------------
 # --------------------------------------------------------------------
-# should be in config file o_O
-
-# letsencrypt tool
-letsencrypt="/root/letsencrypt/letsencrypt-auto"
-# the name of file which letsencrypt will generate
-letsencrypt_issued_cert_file="0000_cert.pem"
-# intermediate CA
-letsencrypt_issued_intermediate_CA_file="0000_chain.pem"
+letsencrypt_zimbra_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 # root CA
-root_CA_file="/root/letsencrypt-zimbra/DSTRootCAX3.pem"
-
-zimbra_service="zimbra"
-zimbra_user="zimbra"
-zimbra_dir="/opt/zimbra"
-
-zimbra_bin_dir="${zimbra_dir}/bin"
-zmcertmgr="${zimbra_bin_dir}/zmcertmgr"
-
-zimbra_ssl_dir="${zimbra_dir}/ssl/zimbra/commercial"
-zimbra_key="${zimbra_ssl_dir}/commercial.key"
-
-# common name in the certificate
-CN="mail.theajty.com"
+root_CA_file="$letsencrypt_zimbra_dir/DSTRootCAX3.pem"
 # subject in request -- does not matter for letsencrypt but must be there for openssl
 cert_subject="/"
 # openssl config skeleton

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -253,9 +253,8 @@ cat "$root_CA_file" "$intermediate_CA_file" > "$chain_file"
     exit 4
 }
 
-
 # finally, restart the Zimbra
-service "$zimbra_service" restart > /dev/null || {
+su -c "zmcontrol start" - "$zimbra_user" || {
     error "Restarting zimbra service failed."
     cleanup
     exit 5

--- a/sendmail-notification-successful.sh
+++ b/sendmail-notification-successful.sh
@@ -1,14 +1,4 @@
 #!/bin/sh
-email=""
-sendmail="/opt/zimbra/postfix/sbin/sendmail"
-subject="Certificate has been renewed"
-message="Hello,
-this is just a kindly reminder that a letsencrypt-zimbra tool
-renewed successfully your Zimbra certificate!
-
-Sincerelly yours,
-cron"
-
 USAGE="USAGE
     $0
 
@@ -19,6 +9,9 @@ USAGE="USAGE
     echo "$USAGE" >&2
     exit 1
 }
+
+letsencrypt_zimbra_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 
 echo "Subject: $subject
 

--- a/sendmail-notification.sh
+++ b/sendmail-notification.sh
@@ -1,14 +1,4 @@
 #!/bin/bash
-email=""
-sendmail="/opt/zimbra/postfix/sbin/sendmail"
-subject="Certificate renewal in $1 day(s)"
-message="Hello,
-this is just a kindly reminder that a letsencrypt-zimbra tool
-will try to obtain and install new zimbra certificate in $1 day(s).
-
-Sincerelly yours,
-cron"
-
 USAGE="USAGE
     $0 days
 
@@ -26,6 +16,8 @@ USAGE="USAGE
     exit 1
 }
 
+letsencrypt_zimbra_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 
 echo "Subject: $subject
 


### PR DESCRIPTION
Just a suggestion. In the best case the script would do the right thing for different environments with upstart/sysvinit/systemd/zmcontrol (e.g. in some docker init).

This is a quick fix because zmcontrol is available everywhere but lacks some features and does not recognise the init scripts or service units of users.