### PR TITLE
Fix: intermediate certificates are in wrong order

### DIFF
--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -256,7 +256,7 @@ readable_file "$intermediate_CA_file" || {
 }
 
 # create one CA chain file
-cat "$root_CA_file" "$intermediate_CA_file" > "$chain_file"
+cat "$intermediate_CA_file" "$root_CA_file" > "$chain_file"
 
 # verify it with Zimbra tool
 "$zmcertmgr" verifycrt comm "$zimbra_key" "$cert_file" "$chain_file" > /dev/null || {


### PR DESCRIPTION
The certificates where in the wrong order. Some clients have problems with that. This fixes it!