### PR TITLE
Fixes on variables in .cfg file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*~
+letsencrypt-zimbra.cfg

--- a/crontab
+++ b/crontab
@@ -1,6 +1,7 @@
+DIR=/opt/letsencrypt-zimbra
 # send a notification a week before the certificate will be obtained
-0 0 1 */2 * root /root/letsencrypt-zimbra/sendmail-notification.sh 7
+0 0 1 */2 * root $DIR/sendmail-notification.sh 7
 # send a notification a day before the certificate will be obtained
-0 0 7 */2 * root /root/letsencrypt-zimbra/sendmail-notification.sh 1
+0 0 7 */2 * root $DIR/sendmail-notification.sh 1
 # obtain the certificate
-0 0 8 */2 * root /root/letsencrypt-zimbra/obtain-and-deploy-letsencrypt-cert.sh && /root/letsencrypt-zimbra/sendmail-notification-successful.sh
+0 0 8 */2 * root $DIR/obtain-and-deploy-letsencrypt-cert.sh email@example.com example.com mail.example.com && $DIR/sendmail-notification-successful.sh

--- a/letsencrypt-zimbra.cfg.example
+++ b/letsencrypt-zimbra.cfg.example
@@ -11,6 +11,7 @@ zimbra_user="zimbra"
 zimbra_dir="/opt/zimbra"
 
 zimbra_bin_dir="${zimbra_dir}/bin"
+zmcontrol="${zimbra_bin_dir}/zmcontrol"
 zmcertmgr="${zimbra_bin_dir}/zmcertmgr"
 
 zimbra_ssl_dir="${zimbra_dir}/ssl/zimbra/commercial"

--- a/letsencrypt-zimbra.cfg.example
+++ b/letsencrypt-zimbra.cfg.example
@@ -23,7 +23,7 @@ letsencrypt_issued_cert_file="0000_cert.pem"
 letsencrypt_issued_intermediate_CA_file="0000_chain.pem"
 
 # root CA certificate - zimbra needs it
-root_CA_file="$letsencrypt_zimbra_dir/DSTRootCAX3.pem"
+root_CA_file="${letsencrypt_zimbra_dir}/DSTRootCAX3.pem"
 
 
 # mail variables ==========================================

--- a/letsencrypt-zimbra.cfg.example
+++ b/letsencrypt-zimbra.cfg.example
@@ -30,6 +30,7 @@ root_CA_file="${letsencrypt_zimbra_dir}/DSTRootCAX3.pem"
 # mail variables ==========================================
 # 8.7 and later: "${zimbra_dir}/common/sbin/sendmail"
 sendmail="${zimbra_dir}/postfix/sbin/sendmail"
+email="insertyourmail@example.com"
 
 ### reminder mail ###
 subject_reminder="Certificate renewal in ${1:-x} day(s)"

--- a/letsencrypt-zimbra.cfg.example
+++ b/letsencrypt-zimbra.cfg.example
@@ -32,8 +32,8 @@ root_CA_file="${letsencrypt_zimbra_dir}/DSTRootCAX3.pem"
 sendmail="${zimbra_dir}/postfix/sbin/sendmail"
 
 ### reminder mail ###
-subject="Certificate renewal in ${1:-x} day(s)"
-message="Hello,
+subject_reminder="Certificate renewal in ${1:-x} day(s)"
+message_reminder="Hello,
 this is just a kindly reminder that a letsencrypt-zimbra tool
 will try to obtain and install new zimbra certificate in ${1:-x} day(s).
 
@@ -41,8 +41,8 @@ Sincerelly yours,
 letsencrypt-zimbra"
 
 ### success mail ###
-subject="Certificate has been renewed"
-message="Hello,
+subject_success="Certificate has been renewed"
+message_success="Hello,
 this is just a kindly reminder that your letsencrypt-zimbra tool
 renewed successfully your Zimbra certificate!
 

--- a/letsencrypt-zimbra.cfg.example
+++ b/letsencrypt-zimbra.cfg.example
@@ -1,0 +1,49 @@
+## letsencrypt-zimbra.cfg
+#
+# A configuration file - shell script - with variables
+# this file is sourced by other scripts
+
+# letsencrypt tool =========================================
+letsencrypt="/opt/certbot/letsencrypt-auto"
+
+zimbra_service="zimbra"
+zimbra_user="zimbra"
+zimbra_dir="/opt/zimbra"
+
+zimbra_bin_dir="${zimbra_dir}/bin"
+zmcertmgr="${zimbra_bin_dir}/zmcertmgr"
+
+zimbra_ssl_dir="${zimbra_dir}/ssl/zimbra/commercial"
+zimbra_key="${zimbra_ssl_dir}/commercial.key"
+
+
+# the name of file which letsencrypt will generate
+letsencrypt_issued_cert_file="0000_cert.pem"
+# intermediate CA
+letsencrypt_issued_intermediate_CA_file="0000_chain.pem"
+
+# root CA certificate - zimbra needs it
+root_CA_file="$letsencrypt_zimbra_dir/DSTRootCAX3.pem"
+
+
+# mail variables ==========================================
+# 8.7 and later: "${zimbra_dir}/common/sbin/sendmail"
+sendmail="${zimbra_dir}/postfix/sbin/sendmail"
+
+### reminder mail ###
+subject="Certificate renewal in ${1:-x} day(s)"
+message="Hello,
+this is just a kindly reminder that a letsencrypt-zimbra tool
+will try to obtain and install new zimbra certificate in ${1:-x} day(s).
+
+Sincerelly yours,
+letsencrypt-zimbra"
+
+### success mail ###
+subject="Certificate has been renewed"
+message="Hello,
+this is just a kindly reminder that your letsencrypt-zimbra tool
+renewed successfully your Zimbra certificate!
+
+Sincerelly yours,
+letsencrypt-zimbra"

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -2,6 +2,8 @@
 # author: Vojtech Myslivec <vojtech@xmyslivec.cz>
 # GPLv2 licence
 
+set -o nounset
+
 SCRIPTNAME=${0##*/}
 
 USAGE="USAGE
@@ -37,7 +39,8 @@ USAGE="USAGE
     Depends on:
         zimbra
         letsencrypt-auto (certbot) utility
-        openssl"
+        openssl
+        service - debian/ubuntu style"
 
 # --------------------------------------------------------------------
 # -- Variables -------------------------------------------------------
@@ -46,16 +49,22 @@ USAGE="USAGE
 
 # letsencrypt (certbot) tool
 letsencrypt="/opt/letsencrypt/letsencrypt-auto"
+
+# zimbra parameters
+zimbra_service="zimbra"
+zimbra_user="zimbra"
+zimbra_dir="/opt/zimbra"
+
+# root CA certificate - zimbra needs it
+root_CA_file="/opt/letsencrypt-zimbra/DSTRootCAX3.pem"
+
+# --------------------------------------------------------------------
+# rest should be kept unchanged
+
 # the name of file which letsencrypt will generate
 letsencrypt_issued_cert_file="0000_cert.pem"
 # intermediate CA
 letsencrypt_issued_intermediate_CA_file="0000_chain.pem"
-# root CA
-root_CA_file="/opt/letsencrypt-zimbra/DSTRootCAX3.pem"
-
-zimbra_service="zimbra"
-zimbra_user="zimbra"
-zimbra_dir="/opt/zimbra"
 
 zimbra_bin_dir="${zimbra_dir}/bin"
 zmcertmgr="${zimbra_bin_dir}/zmcertmgr"

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -19,11 +19,11 @@ USAGE="USAGE
 
     Suitable to be run via cron.
 
-    Friendly notice: restarting Zimbra service take a while (1+ m).
+    Friendly notice: restarting Zimbra service take a while (1 m+).
 
     Depends on:
         zimbra
-        letsencrypt-auto utility
+        letsencrypt-auto (certbot) utility
         openssl"
 
 # --------------------------------------------------------------------
@@ -31,7 +31,7 @@ USAGE="USAGE
 # --------------------------------------------------------------------
 # should be in config file o_O
 
-# letsencrypt tool
+# letsencrypt (certbot) tool
 letsencrypt="/root/letsencrypt/letsencrypt-auto"
 # the name of file which letsencrypt will generate
 letsencrypt_issued_cert_file="0000_cert.pem"
@@ -106,7 +106,7 @@ executable_file() {
 
 cleanup() {
     [ -d "$temp_dir" ] && {
-        rm -rf "$temp_dir" || {
+        rm -r "$temp_dir" || {
             warning "Cannot remove temporary directory '$temp_dir'. You should check it for private data."
         }
     }
@@ -198,7 +198,7 @@ echo "$openssl_config" > "$openssl_config_file"
 # -- Obtaining the certificate ---------------------------------------
 # --------------------------------------------------------------------
 
-# create the certificate signing request [crs]
+# create the certificate signing request [csr]
 openssl req -new -nodes -sha256 -outform der \
     -config "$openssl_config_file" \
     -subj "$cert_subject" \
@@ -213,7 +213,7 @@ openssl req -new -nodes -sha256 -outform der \
 stop_nginx
 
 # ----------------------------------------------------------
-# letsencrypt utility stores the obtained certificates in PWD,
+# letsencrypt utility stores the obtained certificates in PWD
 # so we must cd in the temp directory
 cd "$temp_dir"
 

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -260,11 +260,11 @@ cd "$temp_dir"
 #"$letsencrypt" certonly \
 #  --staging \
 #  --standalone \
-#  --non-interactive --agred-tos \
+#  --non-interactive --agree-tos \
 #  --email "$email" --csr "$request_file" || {
 "$letsencrypt" certonly \
   --standalone \
-  --non-interactive --agred-tos --quiet \
+  --non-interactive --quiet --agree-tos \
   --email "$email" --csr "$request_file" || {
     error "The certificate cannot be obtained with '$letsencrypt' tool."
     start_nginx

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -326,7 +326,9 @@ su -c \
 
 
 # finally, restart the Zimbra
-"$zmcontrol" restart > /dev/null || {
+su -c \
+  "'$zmcontrol' restart" \
+  - "$zimbra_user" > /dev/null || {
     error "Restarting zimbra failed."
     cleanup
     exit 5

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -46,7 +46,7 @@ USAGE="USAGE
 # -- Variables -------------------------------------------------------
 # --------------------------------------------------------------------
 letsencrypt_zimbra_dir="${0%/*}"
-source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
+source "${letsencrypt_zimbra_dir}/letsencrypt-zimbra.cfg"
 
 # subject in request -- does not matter for letsencrypt but must be there for openssl
 cert_subject="/"

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -295,8 +295,8 @@ cat "$root_CA_file" "$intermediate_CA_file" > "$chain_file"
 
 
 # finally, restart the Zimbra
-service "$zimbra_service" restart > /dev/null || {
-    error "Restarting zimbra service failed."
+"$zmcontrol" restart > /dev/null || {
+    error "Restarting zimbra failed."
     cleanup
     exit 5
 }

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -45,32 +45,8 @@ USAGE="USAGE
 # --------------------------------------------------------------------
 # -- Variables -------------------------------------------------------
 # --------------------------------------------------------------------
-# should be in config file o_O
-
-# letsencrypt (certbot) tool
-letsencrypt="/opt/letsencrypt/letsencrypt-auto"
-
-# zimbra parameters
-zimbra_service="zimbra"
-zimbra_user="zimbra"
-zimbra_dir="/opt/zimbra"
-
-# root CA certificate - zimbra needs it
-root_CA_file="/opt/letsencrypt-zimbra/DSTRootCAX3.pem"
-
-# --------------------------------------------------------------------
-# rest should be kept unchanged
-
-# the name of file which letsencrypt will generate
-letsencrypt_issued_cert_file="0000_cert.pem"
-# intermediate CA
-letsencrypt_issued_intermediate_CA_file="0000_chain.pem"
-
-zimbra_bin_dir="${zimbra_dir}/bin"
-zmcertmgr="${zimbra_bin_dir}/zmcertmgr"
-
-zimbra_ssl_dir="${zimbra_dir}/ssl/zimbra/commercial"
-zimbra_key="${zimbra_ssl_dir}/commercial.key"
+letsencrypt_zimbra_dir="${0%/*}"
+source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 
 # subject in request -- does not matter for letsencrypt but must be there for openssl
 cert_subject="/"

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -277,7 +277,7 @@ readable_file "$intermediate_CA_file" || {
 }
 
 # create one CA chain file
-cat "$root_CA_file" "$intermediate_CA_file" > "$chain_file"
+cat "$intermediate_CA_file" "$root_CA_file" > "$chain_file"
 
 # verify it with Zimbra tool
 "$zmcertmgr" verifycrt comm "$zimbra_key" "$cert_file" "$chain_file" > /dev/null || {

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -88,12 +88,26 @@ information() {
     message "info" "$*"
 }
 
+# is $1 a readable ordinary file? (optionaly for user $2)
 readable_file() {
-    [ -f "$1" -a -r "$1" ]
+    if [ -z "${2:-}" ]; then
+        [ -f "$1" -a -r "$1" ]
+    else
+        su -c \
+          "[ -f '$1' -a -r '$1' ]" \
+          - "$2"
+    fi
 }
 
+# is $1 a executable ordinary file? (optionaly for user $2)
 executable_file() {
-    [ -f "$1" -a -x "$1" ]
+    if [ -z "${2:-}" ]; then
+        [ -f "$1" -a -x "$1" ]
+    else
+        su -c \
+          "[ -f '$1' -a -x '$1' ]" \
+          - "$2"
+    fi
 }
 
 cleanup() {
@@ -264,13 +278,26 @@ cert_file="${temp_dir}/${letsencrypt_issued_cert_file}"
 intermediate_CA_file="${temp_dir}/${letsencrypt_issued_intermediate_CA_file}"
 chain_file="${temp_dir}/chain.pem"
 
-readable_file "$cert_file" || {
+touch "$chain_file" || {
+    error "Cannot create a chain file '$chain_file'."
+    cleanup
+    exit 4
+}
+
+# change ownership to zimbra user
+chown -R "${zimbra_user}:" "$temp_dir" || {
+    error "Cannot change ownership of temp files to zimbra user."
+    cleanup
+    exit 4
+}
+
+readable_file "$cert_file" "$zimbra_user" || {
     error "The issued certificate file '$cert_file' isn't readable file. Maybe it was created with different name?"
     cleanup
     exit 4
 }
 
-readable_file "$intermediate_CA_file" || {
+readable_file "$intermediate_CA_file" "$zimbra_user" || {
     error "The issued intermediate CA file '$intermediate_CA_file' isn't readable file. Maybe it was created with different name?"
     cleanup
     exit 4
@@ -280,14 +307,18 @@ readable_file "$intermediate_CA_file" || {
 cat "$intermediate_CA_file" "$root_CA_file" > "$chain_file"
 
 # verify it with Zimbra tool
-"$zmcertmgr" verifycrt comm "$zimbra_key" "$cert_file" "$chain_file" > /dev/null || {
+su -c \
+  "'$zmcertmgr' verifycrt comm '$zimbra_key' '$cert_file' '$chain_file'" \
+  - "$zimbra_user" > /dev/null || {
     error "Verification of the issued certificate with '$zmcertmgr' failed."
     cleanup
     exit 4
 }
 
 # install the certificate to Zimbra
-"$zmcertmgr" deploycrt comm "$cert_file" "$chain_file" > /dev/null || {
+su -c \
+  "'$zmcertmgr' deploycrt comm '$cert_file' '$chain_file'" \
+  - "$zimbra_user" > /dev/null || {
     error "Installation of the issued certificate with '$zmcertmgr' failed."
     cleanup
     exit 4

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -50,6 +50,8 @@ zmcertmgr="${zimbra_bin_dir}/zmcertmgr"
 zimbra_ssl_dir="${zimbra_dir}/ssl/zimbra/commercial"
 zimbra_key="${zimbra_ssl_dir}/commercial.key"
 
+# email for LE registration
+email="mail@example.cz"
 # common name in the certificate
 CN="mail.theajty.com"
 # subject in request -- does not matter for letsencrypt but must be there for openssl
@@ -218,9 +220,16 @@ cd "$temp_dir"
 # TODO implement parameters for
 #   - staging environment
 #   - non-batch/interactive mode
-# exchange the following 2 lines if you need to debug/test this script
-#"$letsencrypt" certonly --standalone --csr "$request_file" --staging || {
-"$letsencrypt" certonly --standalone --csr "$request_file" > /dev/null 2>&1 || {
+# exchange following lines if you need to debug or test this script:
+#"$letsencrypt" certonly \
+#  --staging \
+#  --standalone \
+#  --non-interactive --agred-tos \
+#  --email "$email" --csr "$request_file" || {
+"$letsencrypt" certonly \
+  --standalone \
+  --non-interactive --agred-tos --quiet \
+  --email "$email" --csr "$request_file" || {
     error "The certificate cannot be obtained with '$letsencrypt' tool."
     start_nginx
     cleanup

--- a/sendmail-notification-successful.sh
+++ b/sendmail-notification-successful.sh
@@ -13,7 +13,7 @@ USAGE="USAGE
 letsencrypt_zimbra_dir="${0%/*}"
 source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 
-echo "Subject: $subject
+echo "Subject: $subject_successful
 
-$message" | "$sendmail" "$email"
+$message_successful" | "$sendmail" "$email"
 

--- a/sendmail-notification-successful.sh
+++ b/sendmail-notification-successful.sh
@@ -1,14 +1,4 @@
 #!/bin/sh
-email=""
-sendmail="/opt/zimbra/postfix/sbin/sendmail"
-subject="Certificate has been renewed"
-message="Hello,
-this is just a kindly reminder that a letsencrypt-zimbra tool
-renewed successfully your Zimbra certificate!
-
-Sincerelly yours,
-cron"
-
 USAGE="USAGE
     $0
 
@@ -19,6 +9,9 @@ USAGE="USAGE
     echo "$USAGE" >&2
     exit 1
 }
+
+letsencrypt_zimbra_dir="${0%/*}"
+source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 
 echo "Subject: $subject
 

--- a/sendmail-notification.sh
+++ b/sendmail-notification.sh
@@ -1,14 +1,4 @@
 #!/bin/bash
-email=""
-sendmail="/opt/zimbra/postfix/sbin/sendmail"
-subject="Certificate renewal in $1 day(s)"
-message="Hello,
-this is just a kindly reminder that a letsencrypt-zimbra tool
-will try to obtain and install new zimbra certificate in $1 day(s).
-
-Sincerelly yours,
-cron"
-
 USAGE="USAGE
     $0 days
 
@@ -26,6 +16,8 @@ USAGE="USAGE
     exit 1
 }
 
+letsencrypt_zimbra_dir="${0%/*}"
+source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 
 echo "Subject: $subject
 

--- a/sendmail-notification.sh
+++ b/sendmail-notification.sh
@@ -19,7 +19,7 @@ USAGE="USAGE
 letsencrypt_zimbra_dir="${0%/*}"
 source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 
-echo "Subject: $subject
+echo "Subject: $subject_reminder
 
-$message" | "$sendmail" "$email"
+$message_reminder" | "$sendmail" "$email"
 


### PR DESCRIPTION
Changing some things, because of the notifications bug: due to same variable names for successful and reminder notifications, the last is sent.
Before: variables $message and $subject
After: variables $message_reminder, $subject_reminder, $message_succesful and $subject_succesful

Changed the variables invocation in respective .sh scripts.

Added $email variable in cfg file although.