### PR TITLE
Fixed variables in .cfg file and their invocation

### DIFF
--- a/letsencrypt-zimbra.cfg.example
+++ b/letsencrypt-zimbra.cfg.example
@@ -30,10 +30,11 @@ root_CA_file="${letsencrypt_zimbra_dir}/DSTRootCAX3.pem"
 # mail variables ==========================================
 # 8.7 and later: "${zimbra_dir}/common/sbin/sendmail"
 sendmail="${zimbra_dir}/postfix/sbin/sendmail"
+email="yourmail@example.com"
 
 ### reminder mail ###
-subject="Certificate renewal in ${1:-x} day(s)"
-message="Hello,
+subject_remind="Certificate renewal in ${1:-x} day(s)"
+message_remind="Hello,
 this is just a kindly reminder that a letsencrypt-zimbra tool
 will try to obtain and install new zimbra certificate in ${1:-x} day(s).
 
@@ -41,8 +42,8 @@ Sincerelly yours,
 letsencrypt-zimbra"
 
 ### success mail ###
-subject="Certificate has been renewed"
-message="Hello,
+subject_success="Certificate has been renewed"
+message_success="Hello,
 this is just a kindly reminder that your letsencrypt-zimbra tool
 renewed successfully your Zimbra certificate!
 

--- a/sendmail-notification-successful.sh
+++ b/sendmail-notification-successful.sh
@@ -13,7 +13,7 @@ USAGE="USAGE
 letsencrypt_zimbra_dir="${0%/*}"
 source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 
-echo "Subject: $subject
+echo "Subject: $subject_success
 
-$message" | "$sendmail" "$email"
+$message_success" | "$sendmail" "$email"
 

--- a/sendmail-notification.sh
+++ b/sendmail-notification.sh
@@ -19,7 +19,7 @@ USAGE="USAGE
 letsencrypt_zimbra_dir="${0%/*}"
 source "$letsencrypt_zimbra_dir/letsencrypt-zimbra.cfg"
 
-echo "Subject: $subject
+echo "Subject: $subject_remind
 
-$message" | "$sendmail" "$email"
+$message_remind" | "$sendmail" "$email"
 


### PR DESCRIPTION
1. Separated $message and $subject variables for sending reminder and success message. Now there are four variables: $message_remind, $message_success, $subject_remind and $subject_success, so the right variable is invoked from sendmail scripts.

2. Added $email variable used in sendmail scripts.