### PR TITLE
Avoid usage of empty array

### DIFF
--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -41,7 +41,7 @@ OPTIONS
             certificate, but useful for testing"
 
 # script version: major.minor(.patch)
-VERSION='0.2'
+VERSION='0.2.1'
 
 # --------------------------------------------------------------------
 # -- Functions -------------------------------------------------------

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -11,7 +11,7 @@ set -o nounset
 
 SCRIPTNAME=${0##*/}
 USAGE="USAGE
-    $SCRIPTNAME -h
+    $SCRIPTNAME -h|-V
     $SCRIPTNAME [-q|-v] [-t] [-f|-d days]
 
 DESCRIPTION
@@ -30,6 +30,7 @@ DESCRIPTION
 
 OPTIONS
     -h      Prints this message and exits
+    -V      Prints version of the script
 
     -d num  Do not renew the cert if it exists and will be valid
             for next 'num' days (default 14)
@@ -38,6 +39,9 @@ OPTIONS
     -v      Verbose mode, useful for testing (overrides '-q')
     -t      Use staging Let's Encrypt URL; will issue not-trusted
             certificate, but useful for testing"
+
+# script version: major.minor(.patch)
+VERSION='0.2'
 
 # --------------------------------------------------------------------
 # -- Functions -------------------------------------------------------
@@ -178,10 +182,15 @@ DAYS='14'
 # --------------------------------------------------------------------
 # -- Usage -----------------------------------------------------------
 # --------------------------------------------------------------------
-while getopts ':hd:fqtv' OPT; do
+while getopts ':hVd:fqtv' OPT; do
     case "$OPT" in
         h)
             echo "$USAGE"
+            exit 0
+            ;;
+
+        V)
+            echo "letsencrypt-zimbra version $VERSION"
             exit 0
             ;;
 

--- a/obtain-and-deploy-letsencrypt-cert.sh
+++ b/obtain-and-deploy-letsencrypt-cert.sh
@@ -173,7 +173,7 @@ letsencrypt_issued_cert_file="0000_cert.pem"
 # intermediate CA
 letsencrypt_issued_intermediate_CA_file="0000_chain.pem"
 
-certbot_extra_args=()
+certbot_extra_args=("--non-interactive" "--agree-tos")
 TESTING='false'
 VERBOSE='false'
 FORCE='false'
@@ -356,7 +356,6 @@ cd "$temp_dir"
 information "issue certificate; certbot_extra_args: ${certbot_extra_args[@]}"
 sudo "$letsencrypt" certonly \
   --standalone \
-  --non-interactive --agree-tos \
   "${certbot_extra_args[@]}" \
   --email "$email" --csr "$request_file" || {
     error "The certificate cannot be obtained with '$letsencrypt' tool."


### PR DESCRIPTION
Fix #33 

GNU bash version 4.3 treats usage of empty array as unbound variable. Moving some `certbot` options to the array avoids usage of empty array.